### PR TITLE
Fix compile / install issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 ### Installation 
 ```bash
-git clone https://github.com/StubbornVegeta/StartUp > ~/.config/
+git clone https://github.com/StubbornVegeta/StartUp ~/.config/
 cd ~/.config/StartUp
 ./install.sh
 ```

--- a/install.sh
+++ b/install.sh
@@ -1,13 +1,7 @@
 #!/bin/bash
 
-if [ ! -d "build" ]; then
-    mkdir build
-fi
+mkdir -p build
 cd build
-if [ ! -f "Makefile" ]; then
-    cmake ..
-else
-    make
-fi
+cmake ..
+make
 sudo cp StartUp /usr/local/bin/ 
-

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -4,7 +4,7 @@
 
 void GetLuaTable(int& n, lua_State*& L, const char* var_name, std::vector<std::string>& var) {
   lua_getglobal(L, var_name);
-  n = luaL_len(L,-1);
+  n = lua_objlen(L,-1);
   for ( int i = 0; i < n; ++i) {
     lua_pushnumber(L, i+1);
     lua_gettable(L, -2);
@@ -74,7 +74,7 @@ namespace StartUp {
     luaL_dofile(L, (HOME+"/.config/StartUp/header/header.lua").c_str());
     lua_getglobal(L, style);
     int ret = lua_pcall(L, 0, 1, -1);
-    n = luaL_len(L,-1);
+    n = lua_objlen(L,-1);
      for (int i = 0; i < n; ++i) {
        lua_pushnumber(L, i+1);
        lua_gettable(L, -2);


### PR DESCRIPTION
- Replace `luaL_len` by `lua_objlen`, the latter wasn't defined.
- Fix README.md, because the git clone command was not correct.
- Fix install.sh, because it needed to run twice for cmake and make to
  be both called.